### PR TITLE
feat: compute average forecast deformation per season

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { fetchObservation } from "./services/fetchObservations";
 import { simulateForecast } from "./services/predic";
 import SelectorFunction from "./components/ForecastSelector";
 import generateLinearForecast from "./forecast/ForecastEngine";
+import ForecastDeformationChart from "./components/ForecastDeformationChart";
 
 export default function App() {
   const [location, setLocation] = useState<City>("Stockholm");
@@ -103,6 +104,7 @@ export default function App() {
             })()}
           <div className="bg-gray-100 p-3 rounded-md text-sm mt-4">
             <SelectorFunction value={monthsAhead} onChange={setMonthsAhead} />
+            <ForecastDeformationChart />
             {data && (
               <p
                 style={{

--- a/src/components/ForecastDeformationChart.tsx
+++ b/src/components/ForecastDeformationChart.tsx
@@ -62,6 +62,22 @@ export default function ForecastDeformationChart() {
     });
   }
 
+  if (seasonBucket && seasonBucket) {
+    let averagePerSeason: Record<string, number> = {};
+
+    Object.entries(seasonBucket).forEach(([season, values]) => {
+      if (values.length > 0) {
+        const sumValues: number = (values as number[]).reduce(
+          (acc, val) => acc + val,
+          0
+        );
+        const avgOfSumValues: number = sumValues / values.length;
+        averagePerSeason[season] = avgOfSumValues;
+      }
+    });
+    console.log("Average Per Season: ", averagePerSeason);
+  }
+
   return (
     <div>
       {loading ? (


### PR DESCRIPTION
This update finalizes the seasonal risk analysis logic.

Key Changes:
- Loops through forecast data and groups predicted values by season (Spring, Summer, Autumn, Winter)
- Calculates average deformation per season and stores it in a new summary object
- Logs are working as expected, values reflect seasonal deformation trends