### PR TITLE
feat: finilize seasonal radar chart with mock data and city switching

### DIFF
--- a/src/components/ForecastDeformationChart.tsx
+++ b/src/components/ForecastDeformationChart.tsx
@@ -4,6 +4,7 @@ import { Location } from "../types/apiTypes";
 import { fetchForecastByLocation } from "../services/geoMonitorAPI";
 import { ForecastResponse } from "../types/apiTypes";
 import { seasonBucket } from "../mockData/SeasonBucket";
+import SeasonalRiskChart from "./SeasonalRiskChart";
 
 export default function ForecastDeformationChart() {
   const [location, setLocation] = useState<Location[]>();
@@ -62,9 +63,15 @@ export default function ForecastDeformationChart() {
     });
   }
 
-  if (seasonBucket && seasonBucket) {
-    let averagePerSeason: Record<string, number> = {};
+  type SeasonKey = "spring" | "summer" | "autumn" | "winter";
 
+  let averagePerSeason: Record<SeasonKey, number> = {
+    spring: 0,
+    summer: 0,
+    autumn: 0,
+    winter: 0,
+  };
+  if (seasonBucket && seasonBucket) {
     Object.entries(seasonBucket).forEach(([season, values]) => {
       if (values.length > 0) {
         const sumValues: number = (values as number[]).reduce(
@@ -72,7 +79,8 @@ export default function ForecastDeformationChart() {
           0
         );
         const avgOfSumValues: number = sumValues / values.length;
-        averagePerSeason[season] = avgOfSumValues;
+        const key = season as SeasonKey;
+        averagePerSeason[key] = avgOfSumValues;
       }
     });
     console.log("Average Per Season: ", averagePerSeason);
@@ -87,7 +95,7 @@ export default function ForecastDeformationChart() {
           value={selectCityId}
           onChange={(e) => setSelectCityId(e.target.value)}
         >
-          <option></option>
+          <option>Select City</option>
           {location &&
             location.map((loca) => (
               <option key={loca.id} value={loca.id}>
@@ -95,6 +103,10 @@ export default function ForecastDeformationChart() {
               </option>
             ))}
         </select>
+      )}
+
+      {Object.keys(averagePerSeason).length > 0 && (
+        <SeasonalRiskChart averagePerSeason={averagePerSeason} />
       )}
     </div>
   );

--- a/src/components/SeasonalRiskChart.tsx
+++ b/src/components/SeasonalRiskChart.tsx
@@ -21,7 +21,7 @@ ChartJS.register(
 
 import { Radar } from "react-chartjs-2";
 
-interface SeasonalRiskProps {
+export interface SeasonalRiskProps {
   averagePerSeason: {
     spring: number;
     summer: number;
@@ -38,9 +38,9 @@ export default function SeasonalRiskChart({
     if (value >= 2 && value < 4) return "yellow";
     return "red";
   });
+  const backGrundColor = colorDesignatorLoop;
 
   const data = {
-    colorDesignatorLoop: colorDesignatorLoop,
     labels: ["Spring", "Summer", "Autumn", "Winter"],
     datasets: [
       {
@@ -51,7 +51,8 @@ export default function SeasonalRiskChart({
           averagePerSeason.autumn,
           averagePerSeason.winter,
         ],
-        backgroundColor: "rgba(255,99,132,0.2)",
+        tension: 0.29,
+        backgroundColor: backGrundColor,
         borderColor: "rgba(255,99,132,1)",
         borderWidth: 1,
       },

--- a/src/mockData/GeoMonitorDB.ts
+++ b/src/mockData/GeoMonitorDB.ts
@@ -18,22 +18,36 @@ export const forecastResponses: ForecastResponse[] = [
     locationId: "malm",
     unit: "cm",
     forecast: [
-      {
-        timestamp: "2024-01-11",
-        observed: 0.4,
-        predicted: 2.3,
-      },
+      { timestamp: "2024-01-01", observed: 0.3, predicted: 1.3 },
+      { timestamp: "2024-02-11", observed: 0.7, predicted: 2.0 },
+      { timestamp: "2024-03-13", observed: 0.2, predicted: 2.1 },
+      { timestamp: "2024-04-11", observed: 0.1, predicted: 2.1 },
+      { timestamp: "2024-05-16", observed: 0.5, predicted: 1.6 },
+      { timestamp: "2024-06-09", observed: 0.3, predicted: 1.1 },
+      { timestamp: "2024-07-09", observed: 0.1, predicted: 1.7 },
+      { timestamp: "2024-08-06", observed: 0.1, predicted: 2.7 },
+      { timestamp: "2024-09-03", observed: 0.5, predicted: 1.3 },
+      { timestamp: "2024-10-09", observed: 0.6, predicted: 1.6 },
+      { timestamp: "2024-11-19", observed: 0.6, predicted: 1.1 },
+      { timestamp: "2024-12-30", observed: 0.2, predicted: 1.1 },
     ],
   },
   {
     locationId: "got",
     unit: "cm",
     forecast: [
-      {
-        timestamp: "2024-03-19",
-        observed: 0.3,
-        predicted: 3.3,
-      },
+      { timestamp: "2024-01-10", observed: 0.2, predicted: 1.2 }, // winter
+      { timestamp: "2024-02-20", observed: 0.3, predicted: 1.5 },
+      { timestamp: "2024-03-11", observed: 0.3, predicted: 1.9 },
+      { timestamp: "2024-04-18", observed: 0.4, predicted: 2.3 }, // spring
+      { timestamp: "2024-05-25", observed: 0.5, predicted: 2.6 },
+      { timestamp: "2024-06-02", observed: 0.4, predicted: 3.3 }, // summer
+      { timestamp: "2024-07-13", observed: 0.6, predicted: 5.0 },
+      { timestamp: "2024-08-17", observed: 0.5, predicted: 4.2 },
+      { timestamp: "2024-09-20", observed: 0.3, predicted: 2.2 }, // autumn
+      { timestamp: "2024-10-11", observed: 0.3, predicted: 1.8 },
+      { timestamp: "2024-11-06", observed: 0.2, predicted: 1.4 },
+      { timestamp: "2024-12-29", observed: 0.3, predicted: 1.1 }, // winter
     ],
   },
 ];


### PR DESCRIPTION
- Completed seasonal risk radar chart with dynamic color logic and full mock forecast data
- Added Göteborg as a second location for comparison
- Current implementation shows working city selection, seasonal averaging, and per-point color indicators
- Chart lines are static for now, will be enhanced in the next feature branch

Next: smooth transitions, point radius scaling, and animated line flow